### PR TITLE
Added negative lookbehind to reLeft

### DIFF
--- a/src/armature/BoneMap.ts
+++ b/src/armature/BoneMap.ts
@@ -30,7 +30,7 @@ class BoneParse{
     }
 }
 
-const reLeft    = new RegExp( "\\.l|left|_l", "i" );
+const reLeft    = new RegExp( "\\.l|left|(?<!_r)_l", "i" ); // Don't match patterns like _R_LowerLeg, etc
 const reRight   = new RegExp( "\\.r|right|_r", "i" );
 const Parsers   = [
     new BoneParse( "thigh",     true, "thigh|up.*leg", "twist" ), //upleg | upperleg


### PR DESCRIPTION
By default, models exported from VRoid Studio have a naming convention of `J_Bip_L_/J_Bip_R_` for the limbs. When trying to load one of these models in, the bone parser will pick up `J_Bip_R_LowerLeg` as `shin_l` and subsequently fail to locate `shin_r`. The same happens with `forearm_r`. This adds a negative lookbehind to reLeft to avoid the false positive and actually allows the model to load in properly.

Pic:
![](https://i.imgur.com/tHXKg5K.png)